### PR TITLE
Use TopicDetails everywhere

### DIFF
--- a/rosbag2_snapshot_msgs/CMakeLists.txt
+++ b/rosbag2_snapshot_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/TopicDetails.msg"
   "srv/TriggerSnapshot.srv"
   DEPENDENCIES builtin_interfaces
   ADD_LINTER_TESTS

--- a/rosbag2_snapshot_msgs/msg/TopicDetails.msg
+++ b/rosbag2_snapshot_msgs/msg/TopicDetails.msg
@@ -1,0 +1,2 @@
+string name     # The fully-qualified topic name
+string type     # The fully-qualified message type

--- a/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
+++ b/rosbag2_snapshot_msgs/srv/TriggerSnapshot.srv
@@ -3,7 +3,7 @@ string filename                      # Name of bag file to save snapshot to.
                                      # otherwise, the current datetime and .bag will be appended to the name
                                      #   example: "test" -> test2018-05-23-10-04-20.bag
                                      #   example: "test.bag" -> test.bag
-string[] topics                      # List of topics to include in snapshot.
+TopicDetails[] topics                # List of topics to include in snapshot.
                                      # If empty, all buffered topics will be written
 builtin_interfaces/Time start_time   # Earliest timestamp for a message to be included in written bag
                                      # If time(0), start at the earliest message in each topic's buffer


### PR DESCRIPTION
Since creating generic subscribers and publishers requires topic types, a topic name should always be paired with a topic type. This creates a TopicDetails message and a TopicDetails struct to be used as the key in `std::map`.

Be aware: This changes the service definition for `rosbag2_snapshot_msgs/srv/TriggerSnapshot`. This is necessary as it was previously missing topic types.