### PR TITLE
Add missing timestamps to stored messages

### DIFF
--- a/rosbag2_snapshot/src/snapshotter.cpp
+++ b/rosbag2_snapshot/src/snapshotter.cpp
@@ -467,6 +467,7 @@ bool Snapshotter::writeTopic(
     }
 
     bag_message->topic_name = tm.name;
+    bag_message->time_stamp = msg_it->time.nanoseconds();
     bag_message->serialized_data = std::make_shared<rcutils_uint8_array_t>(
       msg_it->msg->get_rcl_serialized_message()
     );


### PR DESCRIPTION
The messages added to the rosbag did not have valid timestamps so the time of the bag files would show 0s. This fixes this issue.